### PR TITLE
fix: resolve clippy lint and release v0.5.2

### DIFF
--- a/src/ui/handlers.rs
+++ b/src/ui/handlers.rs
@@ -366,7 +366,7 @@ fn handle_help_mode(app_state: &mut AppState, key_code: KeyCode) {
 
     let visible_lines = app_state.help_visible_lines;
 
-    let max_scroll = line_count.saturating_sub(visible_lines).max(0);
+    let max_scroll = line_count.saturating_sub(visible_lines);
 
     match key_code {
         KeyCode::Enter | KeyCode::Esc => {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -644,7 +644,7 @@ fn draw_help_popup(f: &mut Frame, app_state: &mut AppState, area: Rect) {
     app_state.help_visible_lines = visible_lines;
 
     let line_count = app_state.help_text.lines().count();
-    let max_scroll = line_count.saturating_sub(visible_lines).max(0);
+    let max_scroll = line_count.saturating_sub(visible_lines);
 
     app_state.help_scroll = app_state.help_scroll.min(max_scroll);
 


### PR DESCRIPTION
## Summary
- Fixes clippy "unnecessary_min_or_max" lint (CHE-44)
- Removes redundant  after  in  and 

## Changes
- 
- 