### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-21
+
+### Added
+
+- `inspect columns <file> --sheet <name>` to profile column headers, generated safe names, duplicate headers, inferred types, non-null ratios, formula ratios, and sample values.
+- `inspect tables <file> --sheet <name>` to detect table-like regions with ranges, header rows, dimensions, and confidence scores.
+- Regression coverage for structure inspection cases including duplicate headers, blank headers, preamble sections, late headers, multi-table sheets, mixed-type columns, formula columns, and non-ASCII column names.
+- Release branch CI triggers for `release/**` branches.
+
 ## [1.0.0] - 2026-04-20
 
 ### Added
@@ -165,7 +174,8 @@ This is the initial release of excel-cli, a lightweight terminal-based Excel vie
 - Copy, cut, and paste functionality with `y`, `d`, and `p` keys
 - Support for pipe operator when exporting to JSON
 
-[Unreleased]: https://github.com/fuhan666/excel-cli/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/fuhan666/excel-cli/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/fuhan666/excel-cli/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/fuhan666/excel-cli/releases/tag/v1.0.0
 [0.5.2]: https://github.com/fuhan666/excel-cli/releases/tag/v0.5.2
 [0.5.1]: https://github.com/fuhan666/excel-cli/releases/tag/v0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "excel-cli"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
-description = "A single-file read-only Excel CLI for AI and scripting. Inspect, read, and browse Excel files with a stable JSON API."
+description = "Excel CLI for AI, scripting, and terminal users. Headless JSON API for automation, plus a Vim-like TUI for interactive browsing and editing."
 license = "MIT"
 repository = "https://github.com/fuhan666/excel-cli"
-keywords = ["Excel", "Excel-export", "Excel-json", "calamine", "ratatui"]
-categories = ["command-line-utilities", "development-tools", "data-structures", "parsing"]
-exclude = [".tests", "/.github", "AGENTS.md", "CHANGELOG.md", ".gitignore"]
+keywords = ["excel", "cli", "ai", "tui", "spreadsheet"]
+categories = ["command-line-interface", "command-line-utilities", "development-tools", "parsing"]
+exclude = ["/.tests", "/.github", "AGENTS.md", "CHANGELOG.md", ".gitignore"]
 
 [dependencies]
 ratatui = "0.24.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Excel-CLI
 
-An Excel CLI for AI and scripting. Inspect, read, and browse Excel files with a stable JSON API.
+An Excel CLI for AI, scripting, and terminal users. Inspect and read headlessly via a stable JSON API, or browse and edit interactively with a Vim-like TUI.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ excel-cli inspect sheet path/to/your/file.xlsx --sheet-index 0
 # Sample data from a sheet
 excel-cli inspect sample path/to/your/file.xlsx --sheet Orders --rows 10
 
+# Inspect columns with auto-detected headers
+excel-cli inspect columns path/to/your/file.xlsx --sheet Orders --header-row auto
+
+# Inspect table-like regions in a sheet
+excel-cli inspect tables path/to/your/file.xlsx --sheet Orders
+
 # Read a single cell
 excel-cli read cell path/to/your/file.xlsx --sheet Orders --cell B2
 
@@ -119,6 +125,22 @@ Headless success responses follow a stable envelope:
   "data": { ... },
   "warnings": []
 }
+```
+
+### Structure Inspection
+
+`inspect columns` profiles each column in a sheet so you can choose stable field names for later commands. The response data includes `columns`, where each column has `index`, original `name`, generated `safe_name`, `is_duplicate`, best-effort `inferred_type`, `non_null_ratio`, `formula_ratio`, and `sample_values`. The response metadata includes `header_row_mode`, `resolved_header_row`, `column_count`, and `data_row_count`.
+
+```bash
+excel-cli inspect columns path/to/your/file.xlsx --sheet Orders --header-row auto
+excel-cli inspect columns path/to/your/file.xlsx --sheet Orders --header-row 2 --format text
+```
+
+`inspect tables` detects contiguous table-like regions in a sheet. The response data includes `data.candidates`; each candidate includes `range`, `header_row`, `column_count`, `row_count`, and `confidence`. The response metadata includes `candidate_count`.
+
+```bash
+excel-cli inspect tables path/to/your/file.xlsx --sheet Orders
+excel-cli inspect tables path/to/your/file.xlsx --sheet Orders --format text
 ```
 
 Headless error responses follow a stable envelope:

--- a/README_zh.md
+++ b/README_zh.md
@@ -65,6 +65,12 @@ excel-cli inspect sheet path/to/your/file.xlsx --sheet-index 0
 # 从工作表中采样数据
 excel-cli inspect sample path/to/your/file.xlsx --sheet Orders --rows 10
 
+# 检查列信息（自动检测表头）
+excel-cli inspect columns path/to/your/file.xlsx --sheet Orders --header-row auto
+
+# 检查表格区域
+excel-cli inspect tables path/to/your/file.xlsx --sheet Orders
+
 # 读取单个单元格
 excel-cli read cell path/to/your/file.xlsx --sheet Orders --cell B2
 
@@ -119,6 +125,22 @@ excel-cli ui path/to/your/file.xlsx
   "data": { ... },
   "warnings": []
 }
+```
+
+### 结构检查
+
+`inspect columns` 分析工作表中的每一列，帮助你为后续命令选择稳定的字段名。响应数据包含 `columns`，每列包含 `index`、原始 `name`、生成的 `safe_name`、`is_duplicate`、尽力推断的 `inferred_type`、`non_null_ratio`、`formula_ratio` 和 `sample_values`。响应元数据包含 `header_row_mode`、`resolved_header_row`、`column_count` 和 `data_row_count`。
+
+```bash
+excel-cli inspect columns path/to/your/file.xlsx --sheet Orders --header-row auto
+excel-cli inspect columns path/to/your/file.xlsx --sheet Orders --header-row 2 --format text
+```
+
+`inspect tables` 检测工作表中的连续表格区域。响应数据包含 `data.candidates`；每个候选区域包含 `range`、`header_row`、`column_count`、`row_count` 和 `confidence`。响应元数据包含 `candidate_count`。
+
+```bash
+excel-cli inspect tables path/to/your/file.xlsx --sheet Orders
+excel-cli inspect tables path/to/your/file.xlsx --sheet Orders --format text
 ```
 
 无界面错误响应遵循稳定的信封结构：

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,6 +1,6 @@
 # Excel-CLI
 
-面向 AI 和脚本场景的 Excel CLI。通过稳定的 JSON API 检查、读取和浏览 Excel 文件。
+面向 AI、脚本和终端用户的 Excel 命令行工具。提供 JSON API 供自动化场景调用，同时内置交互式 TUI，支持类 Vim 快捷键浏览和编辑表格。
 
 ## 功能特性
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -94,6 +94,23 @@ pub enum InspectCommands {
         #[arg(long, value_enum, default_value = "json")]
         format: OutputFormat,
     },
+    /// Inspect column headers and inferred column metadata
+    Columns {
+        /// Excel file path
+        file: PathBuf,
+
+        /// Sheet name (exact match)
+        #[arg(long)]
+        sheet: String,
+
+        /// Header row: auto or 1-based index
+        #[arg(long, default_value = "auto")]
+        header_row: String,
+
+        /// Output format
+        #[arg(long, value_enum, default_value = "json")]
+        format: OutputFormat,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -111,6 +111,19 @@ pub enum InspectCommands {
         #[arg(long, value_enum, default_value = "json")]
         format: OutputFormat,
     },
+    /// Detect table-like regions in a sheet
+    Tables {
+        /// Excel file path
+        file: PathBuf,
+
+        /// Sheet name (exact match)
+        #[arg(long)]
+        sheet: String,
+
+        /// Output format
+        #[arg(long, value_enum, default_value = "json")]
+        format: OutputFormat,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -8,9 +8,13 @@ pub fn handle(file: std::path::PathBuf, rule: Option<String>) -> Result<Value, A
 
     // v1.0.0: check is namespace-only. Any attempt to run a rule is rejected.
     let message = if let Some(r) = rule {
-        format!("Check rule '{}' is not implemented in v1.0.0. Quality checks are planned for v1.3.0.", r)
+        format!(
+            "Check rule '{}' is not implemented in v1.0.0. Quality checks are planned for v1.3.0.",
+            r
+        )
     } else {
-        "Check command requires a --rule argument. Quality checks are planned for v1.3.0.".to_string()
+        "Check command requires a --rule argument. Quality checks are planned for v1.3.0."
+            .to_string()
     };
 
     Err(AppError::CheckNotImplemented { message })

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -10,6 +10,7 @@ pub fn dispatch(cli: Cli) -> Result<(Value, crate::cli::args::OutputFormat), App
                 crate::cli::args::InspectCommands::Workbook { format, .. } => format.clone(),
                 crate::cli::args::InspectCommands::Sheet { format, .. } => format.clone(),
                 crate::cli::args::InspectCommands::Sample { format, .. } => format.clone(),
+                crate::cli::args::InspectCommands::Columns { format, .. } => format.clone(),
             };
             let value = crate::cli::inspect::handle(subcommand)?;
             Ok((value, format))
@@ -33,8 +34,7 @@ pub fn dispatch(cli: Cli) -> Result<(Value, crate::cli::args::OutputFormat), App
                 .map_err(crate::cli::error::anyhow_to_app_error)?;
             let app_state = crate::app::AppState::new(workbook, file)
                 .map_err(crate::cli::error::anyhow_to_app_error)?;
-            crate::ui::run_app(app_state)
-                .map_err(crate::cli::error::anyhow_to_app_error)?;
+            crate::ui::run_app(app_state).map_err(crate::cli::error::anyhow_to_app_error)?;
             Ok((
                 crate::cli::envelope::success_envelope(
                     "ui",

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -11,6 +11,7 @@ pub fn dispatch(cli: Cli) -> Result<(Value, crate::cli::args::OutputFormat), App
                 crate::cli::args::InspectCommands::Sheet { format, .. } => format.clone(),
                 crate::cli::args::InspectCommands::Sample { format, .. } => format.clone(),
                 crate::cli::args::InspectCommands::Columns { format, .. } => format.clone(),
+                crate::cli::args::InspectCommands::Tables { format, .. } => format.clone(),
             };
             let value = crate::cli::inspect::handle(subcommand)?;
             Ok((value, format))

--- a/src/cli/inspect.rs
+++ b/src/cli/inspect.rs
@@ -32,6 +32,11 @@ pub fn handle(cmd: InspectCommands) -> Result<Value, AppError> {
             header_row,
             format: _,
         } => inspect_columns(file, sheet, header_row),
+        InspectCommands::Tables {
+            file,
+            sheet,
+            format: _,
+        } => inspect_tables(file, sheet),
     }
 }
 
@@ -392,6 +397,44 @@ fn inspect_columns(
     ))
 }
 
+fn inspect_tables(file: std::path::PathBuf, sheet: String) -> Result<Value, AppError> {
+    let format_str = file_format(&file);
+    let path_str = file.to_string_lossy().to_string();
+
+    let mut workbook =
+        open_workbook(&file, false).map_err(crate::cli::error::anyhow_to_app_error)?;
+
+    let sheet_target = Some(sheet);
+    let index = resolve_sheet_target(&workbook, &sheet_target, &None)?;
+    let sheet_name = workbook.get_sheet_names()[index].clone();
+
+    workbook
+        .ensure_sheet_loaded(index, &sheet_name)
+        .map_err(crate::cli::error::anyhow_to_app_error)?;
+
+    let sheet_obj = workbook
+        .get_sheet_by_index(index)
+        .with_context(|| format!("Sheet '{}' not found", sheet_name))
+        .map_err(crate::cli::error::anyhow_to_app_error)?;
+
+    let candidates = detect_table_candidates(sheet_obj);
+    let candidate_count = candidates.len();
+
+    Ok(envelope::success_envelope(
+        "inspect.tables",
+        &path_str,
+        &format_str,
+        envelope::target_sheet(&sheet_name, index),
+        json!({
+            "candidate_count": candidate_count,
+        }),
+        json!({
+            "candidates": candidates,
+        }),
+        vec![],
+    ))
+}
+
 fn resolve_columns_header_row(
     workbook: &crate::excel::Workbook,
     sheet_index: usize,
@@ -586,4 +629,243 @@ fn ratio(numerator: usize, denominator: usize) -> f64 {
     } else {
         numerator as f64 / denominator as f64
     }
+}
+
+#[derive(Clone)]
+struct TableCandidate {
+    start_row: usize,
+    start_col: usize,
+    end_row: usize,
+    end_col: usize,
+    confidence: f64,
+}
+
+fn detect_table_candidates(sheet: &Sheet) -> Vec<Value> {
+    if sheet.max_rows == 0 || sheet.max_cols == 0 {
+        return Vec::new();
+    }
+
+    let mut candidates = Vec::new();
+
+    for row in 1..=sheet.max_rows {
+        let spans = non_empty_spans(sheet, row);
+        for (start_col, end_col) in spans {
+            let column_count = end_col - start_col + 1;
+            if column_count < 2 {
+                continue;
+            }
+
+            if !is_header_like(sheet, row, start_col, end_col) {
+                continue;
+            }
+
+            if row > 1 && previous_row_blocks_header_candidate(sheet, row, start_col, end_col) {
+                continue;
+            }
+
+            let Some(end_row) = extend_candidate(sheet, row, start_col, end_col) else {
+                continue;
+            };
+
+            let confidence = score_candidate(sheet, row, start_col, end_row, end_col);
+            if confidence < 0.5 {
+                continue;
+            }
+
+            candidates.push(TableCandidate {
+                start_row: row,
+                start_col,
+                end_row,
+                end_col,
+                confidence,
+            });
+        }
+    }
+
+    candidates.sort_by_key(|candidate| (candidate.start_row, candidate.start_col));
+    let candidates = remove_duplicate_candidates(candidates);
+
+    candidates
+        .into_iter()
+        .map(|candidate| {
+            let range = format!(
+                "{}{}:{}{}",
+                index_to_col_name(candidate.start_col),
+                candidate.start_row,
+                index_to_col_name(candidate.end_col),
+                candidate.end_row
+            );
+            json!({
+                "range": range,
+                "header_row": candidate.start_row,
+                "column_count": candidate.end_col - candidate.start_col + 1,
+                "row_count": candidate.end_row - candidate.start_row + 1,
+                "confidence": candidate.confidence,
+            })
+        })
+        .collect()
+}
+
+fn non_empty_spans(sheet: &Sheet, row: usize) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut current_start = None;
+
+    for col in 1..=sheet.max_cols {
+        if cell_has_value(sheet, row, col) {
+            current_start.get_or_insert(col);
+        } else if let Some(start) = current_start.take() {
+            spans.push((start, col - 1));
+        }
+    }
+
+    if let Some(start) = current_start {
+        spans.push((start, sheet.max_cols));
+    }
+
+    spans
+}
+
+fn is_header_like(sheet: &Sheet, row: usize, start_col: usize, end_col: usize) -> bool {
+    let width = end_col - start_col + 1;
+    let non_empty = non_empty_count(sheet, row, start_col, end_col);
+    if non_empty < 2 {
+        return false;
+    }
+
+    let fill_ratio = non_empty as f64 / width as f64;
+    let text_ratio = text_count(sheet, row, start_col, end_col) as f64 / non_empty as f64;
+    fill_ratio >= 0.8 && text_ratio >= 0.5
+}
+
+fn extend_candidate(
+    sheet: &Sheet,
+    header_row: usize,
+    start_col: usize,
+    end_col: usize,
+) -> Option<usize> {
+    let mut end_row = header_row;
+    let mut has_data_row = false;
+
+    for row in (header_row + 1)..=sheet.max_rows {
+        if row_has_any_value(sheet, row, start_col, end_col) {
+            end_row = row;
+            has_data_row = true;
+        } else {
+            break;
+        }
+    }
+
+    has_data_row.then_some(end_row)
+}
+
+fn score_candidate(
+    sheet: &Sheet,
+    header_row: usize,
+    start_col: usize,
+    end_row: usize,
+    end_col: usize,
+) -> f64 {
+    let width = end_col - start_col + 1;
+    let header_non_empty = non_empty_count(sheet, header_row, start_col, end_col);
+    let header_fill = header_non_empty as f64 / width as f64;
+    let header_text =
+        text_count(sheet, header_row, start_col, end_col) as f64 / header_non_empty.max(1) as f64;
+
+    let data_rows = end_row.saturating_sub(header_row);
+    let data_fill = if data_rows == 0 {
+        0.0
+    } else {
+        let filled_cells: usize = ((header_row + 1)..=end_row)
+            .map(|row| non_empty_count(sheet, row, start_col, end_col))
+            .sum();
+        filled_cells as f64 / (data_rows * width) as f64
+    };
+
+    let height_score = (data_rows as f64 / 3.0).min(1.0);
+    let before_boundary =
+        header_row == 1 || !row_has_any_value(sheet, header_row - 1, start_col, end_col);
+    let after_boundary =
+        end_row == sheet.max_rows || !row_has_any_value(sheet, end_row + 1, start_col, end_col);
+    let boundary_score = match (before_boundary, after_boundary) {
+        (true, true) => 1.0,
+        (true, false) | (false, true) => 0.5,
+        (false, false) => 0.0,
+    };
+
+    let confidence = header_fill * 0.25
+        + header_text * 0.25
+        + data_fill * 0.25
+        + height_score * 0.15
+        + boundary_score * 0.10;
+
+    (confidence.clamp(0.0, 1.0) * 100.0).round() / 100.0
+}
+
+fn remove_duplicate_candidates(candidates: Vec<TableCandidate>) -> Vec<TableCandidate> {
+    let mut kept: Vec<TableCandidate> = Vec::new();
+
+    'candidate: for candidate in candidates {
+        for existing in &kept {
+            if same_table_region(existing, &candidate) {
+                continue 'candidate;
+            }
+        }
+        kept.push(candidate);
+    }
+
+    kept
+}
+
+fn same_table_region(left: &TableCandidate, right: &TableCandidate) -> bool {
+    left.start_row == right.start_row
+        && left.start_col == right.start_col
+        && left.end_row == right.end_row
+        && left.end_col == right.end_col
+}
+
+fn previous_row_blocks_header_candidate(
+    sheet: &Sheet,
+    row: usize,
+    start_col: usize,
+    end_col: usize,
+) -> bool {
+    let width = end_col - start_col + 1;
+    let previous_non_empty = non_empty_count(sheet, row - 1, start_col, end_col);
+    previous_non_empty >= 2 && previous_non_empty as f64 / width as f64 >= 0.5
+}
+
+fn row_has_any_value(sheet: &Sheet, row: usize, start_col: usize, end_col: usize) -> bool {
+    (start_col..=end_col).any(|col| cell_has_value(sheet, row, col))
+}
+
+fn non_empty_count(sheet: &Sheet, row: usize, start_col: usize, end_col: usize) -> usize {
+    (start_col..=end_col)
+        .filter(|&col| cell_has_value(sheet, row, col))
+        .count()
+}
+
+fn text_count(sheet: &Sheet, row: usize, start_col: usize, end_col: usize) -> usize {
+    (start_col..=end_col)
+        .filter(|&col| {
+            cell_has_value(sheet, row, col)
+                && matches!(table_cell_type(sheet, row, col), Some(CellType::Text))
+        })
+        .count()
+}
+
+fn cell_has_value(sheet: &Sheet, row: usize, col: usize) -> bool {
+    sheet
+        .data
+        .get(row)
+        .and_then(|row_data| row_data.get(col))
+        .map(|cell| !cell.value.trim().is_empty() || cell.formula.is_some())
+        .unwrap_or(false)
+}
+
+fn table_cell_type(sheet: &Sheet, row: usize, col: usize) -> Option<CellType> {
+    sheet
+        .data
+        .get(row)
+        .and_then(|row_data| row_data.get(col))
+        .map(|cell| cell.cell_type.clone())
 }

--- a/src/cli/inspect.rs
+++ b/src/cli/inspect.rs
@@ -1,10 +1,11 @@
 use anyhow::Context;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 
 use crate::cli::args::{resolve_sheet_target, InspectCommands};
 use crate::cli::envelope;
 use crate::cli::error::AppError;
-use crate::excel::open_workbook;
+use crate::excel::{open_workbook, Cell, CellType, Sheet};
 use crate::utils::{index_to_col_name, parse_range};
 
 pub fn handle(cmd: InspectCommands) -> Result<Value, AppError> {
@@ -25,6 +26,12 @@ pub fn handle(cmd: InspectCommands) -> Result<Value, AppError> {
             header_row,
             format: _,
         } => inspect_sample(file, sheet, sheet_index, range, rows, header_row),
+        InspectCommands::Columns {
+            file,
+            sheet,
+            header_row,
+            format: _,
+        } => inspect_columns(file, sheet, header_row),
     }
 }
 
@@ -39,8 +46,7 @@ fn inspect_workbook(file: std::path::PathBuf) -> Result<Value, AppError> {
     let format_str = file_format(&file);
     let path_str = file.to_string_lossy().to_string();
 
-    let workbook = open_workbook(&file, false)
-        .map_err(crate::cli::error::anyhow_to_app_error)?;
+    let workbook = open_workbook(&file, false).map_err(crate::cli::error::anyhow_to_app_error)?;
 
     let sheets: Vec<Value> = workbook
         .get_sheet_names()
@@ -85,8 +91,8 @@ fn inspect_sheet(
     let format_str = file_format(&file);
     let path_str = file.to_string_lossy().to_string();
 
-    let mut workbook = open_workbook(&file, false)
-        .map_err(crate::cli::error::anyhow_to_app_error)?;
+    let mut workbook =
+        open_workbook(&file, false).map_err(crate::cli::error::anyhow_to_app_error)?;
 
     let index = resolve_sheet_target(&workbook, &sheet, &sheet_index)?;
     let sheet_name = workbook.get_sheet_names()[index].clone();
@@ -149,8 +155,8 @@ fn inspect_sample(
     let format_str = file_format(&file);
     let path_str = file.to_string_lossy().to_string();
 
-    let mut workbook = open_workbook(&file, false)
-        .map_err(crate::cli::error::anyhow_to_app_error)?;
+    let mut workbook =
+        open_workbook(&file, false).map_err(crate::cli::error::anyhow_to_app_error)?;
 
     let index = resolve_sheet_target(&workbook, &sheet, &sheet_index)?;
     let sheet_name = workbook.get_sheet_names()[index].clone();
@@ -164,16 +170,13 @@ fn inspect_sample(
         .with_context(|| format!("Sheet '{}' not found", sheet_name))
         .map_err(crate::cli::error::anyhow_to_app_error)?;
 
-    let used_range = workbook
-        .get_used_range(index)
-        .unwrap_or_default();
+    let used_range = workbook.get_used_range(index).unwrap_or_default();
 
     // Determine the sample range
     let ((mut start_row, mut start_col), (mut end_row, mut end_col)) = if let Some(ref r) = range {
-        parse_range(r)
-            .ok_or_else(|| AppError::InvalidQuery {
-                message: format!("Invalid range format: {}", r),
-            })?
+        parse_range(r).ok_or_else(|| AppError::InvalidQuery {
+            message: format!("Invalid range format: {}", r),
+        })?
     } else if !used_range.is_empty() {
         parse_range(&used_range).unwrap_or(((1, 1), (1, 1)))
     } else {
@@ -305,4 +308,282 @@ fn inspect_sample(
         data,
         vec![],
     ))
+}
+
+fn inspect_columns(
+    file: std::path::PathBuf,
+    sheet: String,
+    header_row: String,
+) -> Result<Value, AppError> {
+    let format_str = file_format(&file);
+    let path_str = file.to_string_lossy().to_string();
+
+    let mut workbook =
+        open_workbook(&file, false).map_err(crate::cli::error::anyhow_to_app_error)?;
+
+    let index = workbook
+        .resolve_sheet_by_name(&sheet)
+        .map_err(|e| AppError::TargetNotFound {
+            message: e.to_string(),
+        })?;
+    let sheet_name = workbook.get_sheet_names()[index].clone();
+
+    workbook
+        .ensure_sheet_loaded(index, &sheet_name)
+        .map_err(crate::cli::error::anyhow_to_app_error)?;
+
+    let resolved_header = resolve_columns_header_row(&workbook, index, &header_row)?;
+    let sheet_obj = workbook
+        .get_sheet_by_index(index)
+        .with_context(|| format!("Sheet '{}' not found", sheet_name))
+        .map_err(crate::cli::error::anyhow_to_app_error)?;
+
+    let header_names = column_header_names(sheet_obj, resolved_header);
+    let duplicate_flags = duplicate_header_flags(&header_names);
+    let safe_names = stable_safe_names(&header_names);
+    let data_start_row = resolved_header.map_or(1, |row| row.saturating_add(1));
+    let data_row_count = if sheet_obj.max_rows >= data_start_row {
+        sheet_obj.max_rows - data_start_row + 1
+    } else {
+        0
+    };
+
+    let columns: Vec<Value> = (1..=sheet_obj.max_cols)
+        .map(|col| {
+            let stats = analyze_column(sheet_obj, col, data_start_row, data_row_count);
+            json!({
+                "index": col,
+                "name": header_names.get(col - 1).cloned().unwrap_or_default(),
+                "safe_name": safe_names.get(col - 1).cloned().unwrap_or_else(|| {
+                    format!("col_{}", index_to_col_name(col))
+                }),
+                "is_duplicate": duplicate_flags.get(col - 1).copied().unwrap_or(false),
+                "inferred_type": stats.inferred_type,
+                "non_null_ratio": ratio(stats.non_null_count, data_row_count),
+                "formula_ratio": ratio(stats.formula_count, data_row_count),
+                "sample_values": stats.sample_values,
+            })
+        })
+        .collect();
+
+    let mut warnings = Vec::new();
+    if header_row == "auto" && resolved_header.is_none() {
+        warnings.push(json!({
+            "code": "header_not_detected",
+            "message": "No header row was detected; column names are synthetic.",
+        }));
+    }
+
+    Ok(envelope::success_envelope(
+        "inspect.columns",
+        &path_str,
+        &format_str,
+        envelope::target_sheet(&sheet_name, index),
+        json!({
+            "header_row_mode": header_row,
+            "resolved_header_row": resolved_header,
+            "column_count": sheet_obj.max_cols,
+            "data_row_count": data_row_count,
+        }),
+        json!({
+            "columns": columns,
+        }),
+        warnings,
+    ))
+}
+
+fn resolve_columns_header_row(
+    workbook: &crate::excel::Workbook,
+    sheet_index: usize,
+    header_row: &str,
+) -> Result<Option<usize>, AppError> {
+    if header_row == "auto" {
+        let (_, recommended) = workbook
+            .find_header_candidates(sheet_index)
+            .map_err(crate::cli::error::anyhow_to_app_error)?;
+        return Ok(recommended);
+    }
+
+    let row = header_row
+        .parse::<usize>()
+        .map_err(|_| AppError::InvalidQuery {
+            message: format!("Invalid header row: {}", header_row),
+        })?;
+
+    let sheet =
+        workbook
+            .get_sheet_by_index(sheet_index)
+            .ok_or_else(|| AppError::TargetNotFound {
+                message: "Sheet index out of range".to_string(),
+            })?;
+
+    if row < 1 || row > sheet.max_rows {
+        return Err(AppError::InvalidQuery {
+            message: format!(
+                "Header row {} is outside the used row range 1..={}",
+                row, sheet.max_rows
+            ),
+        });
+    }
+
+    Ok(Some(row))
+}
+
+fn column_header_names(sheet: &Sheet, resolved_header: Option<usize>) -> Vec<String> {
+    (1..=sheet.max_cols)
+        .map(|col| {
+            resolved_header
+                .and_then(|row| cell_at(sheet, row, col))
+                .map(|cell| cell.value.clone())
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+fn duplicate_header_flags(headers: &[String]) -> Vec<bool> {
+    let mut counts = HashMap::new();
+    for header in headers {
+        let normalized = header.trim();
+        if !normalized.is_empty() {
+            *counts.entry(normalized.to_string()).or_insert(0usize) += 1;
+        }
+    }
+
+    headers
+        .iter()
+        .map(|header| {
+            let normalized = header.trim();
+            !normalized.is_empty() && counts.get(normalized).copied().unwrap_or(0) > 1
+        })
+        .collect()
+}
+
+fn stable_safe_names(headers: &[String]) -> Vec<String> {
+    let mut counts = HashMap::new();
+
+    headers
+        .iter()
+        .enumerate()
+        .map(|(offset, header)| {
+            let col = offset + 1;
+            let base = slugify_header(header, col);
+            let count = counts.entry(base.clone()).or_insert(0usize);
+            *count += 1;
+            if *count == 1 {
+                base
+            } else {
+                format!("{base}_{count}")
+            }
+        })
+        .collect()
+}
+
+fn slugify_header(header: &str, col: usize) -> String {
+    let mut slug = String::new();
+    let mut last_was_separator = false;
+
+    for ch in header.trim().chars() {
+        if ch.is_alphanumeric() {
+            for lower in ch.to_lowercase() {
+                slug.push(lower);
+            }
+            last_was_separator = false;
+        } else if !slug.is_empty() && !last_was_separator {
+            slug.push('_');
+            last_was_separator = true;
+        }
+    }
+
+    while slug.ends_with('_') {
+        slug.pop();
+    }
+
+    if slug.is_empty() {
+        format!("col_{}", index_to_col_name(col))
+    } else {
+        slug
+    }
+}
+
+struct ColumnStats {
+    inferred_type: &'static str,
+    non_null_count: usize,
+    formula_count: usize,
+    sample_values: Vec<Value>,
+}
+
+fn analyze_column(
+    sheet: &Sheet,
+    col: usize,
+    data_start_row: usize,
+    data_row_count: usize,
+) -> ColumnStats {
+    let mut inferred_type = None;
+    let mut is_mixed = false;
+    let mut non_null_count = 0usize;
+    let mut formula_count = 0usize;
+    let mut sample_values = Vec::new();
+
+    if data_row_count > 0 {
+        for row in data_start_row..data_start_row + data_row_count {
+            if let Some(cell) = cell_at(sheet, row, col) {
+                if cell.is_formula || cell.formula.is_some() {
+                    formula_count += 1;
+                }
+
+                if is_non_null(cell) {
+                    non_null_count += 1;
+
+                    if sample_values.len() < 5 {
+                        sample_values.push(crate::json_export::process_cell_value(cell));
+                    }
+
+                    if let Some(cell_type) = inferred_kind(cell) {
+                        match inferred_type {
+                            None => inferred_type = Some(cell_type),
+                            Some(existing) if existing == cell_type => {}
+                            Some(_) => is_mixed = true,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ColumnStats {
+        inferred_type: if is_mixed {
+            "mixed"
+        } else {
+            inferred_type.unwrap_or("string")
+        },
+        non_null_count,
+        formula_count,
+        sample_values,
+    }
+}
+
+fn cell_at(sheet: &Sheet, row: usize, col: usize) -> Option<&Cell> {
+    sheet.data.get(row).and_then(|row_data| row_data.get(col))
+}
+
+fn is_non_null(cell: &Cell) -> bool {
+    !cell.value.is_empty()
+}
+
+fn inferred_kind(cell: &Cell) -> Option<&'static str> {
+    match cell.cell_type {
+        CellType::Text => Some("string"),
+        CellType::Number => Some("number"),
+        CellType::Date => Some("date"),
+        CellType::Boolean => Some("boolean"),
+        CellType::Empty => None,
+    }
+}
+
+fn ratio(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -37,6 +37,7 @@ fn write_text(value: &Value) -> Result<(), AppError> {
         "inspect.sheet" => write_text_sheet(value)?,
         "inspect.sample" => write_text_sample(value)?,
         "inspect.columns" => write_text_columns(value)?,
+        "inspect.tables" => write_text_tables(value)?,
         "read.cell" => write_text_cell(value)?,
         "read.range" => write_text_range(value)?,
         "read.rows" => write_text_rows(value)?,
@@ -145,6 +146,24 @@ fn format_ratio(value: f64) -> String {
             .trim_end_matches('.')
             .to_string()
     }
+}
+
+fn write_text_tables(value: &Value) -> Result<(), AppError> {
+    let data = &value["data"];
+    if let Some(candidates) = data["candidates"].as_array() {
+        for candidate in candidates {
+            let range = candidate["range"].as_str().unwrap_or("");
+            let header_row = candidate["header_row"].as_u64().unwrap_or(0);
+            let column_count = candidate["column_count"].as_u64().unwrap_or(0);
+            let row_count = candidate["row_count"].as_u64().unwrap_or(0);
+            let confidence = candidate["confidence"].as_f64().unwrap_or(0.0);
+            println!(
+                "{}\theader_row={}\tcolumns={}\trows={}\tconfidence={:.2}",
+                range, header_row, column_count, row_count, confidence
+            );
+        }
+    }
+    Ok(())
 }
 
 fn write_text_cell(value: &Value) -> Result<(), AppError> {

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -36,6 +36,7 @@ fn write_text(value: &Value) -> Result<(), AppError> {
         "inspect.workbook" => write_text_workbook(value)?,
         "inspect.sheet" => write_text_sheet(value)?,
         "inspect.sample" => write_text_sample(value)?,
+        "inspect.columns" => write_text_columns(value)?,
         "read.cell" => write_text_cell(value)?,
         "read.range" => write_text_range(value)?,
         "read.rows" => write_text_rows(value)?,
@@ -102,15 +103,48 @@ fn write_text_sample(value: &Value) -> Result<(), AppError> {
     } else if let Some(records) = data["records"].as_array() {
         for record in records {
             if let Some(obj) = record.as_object() {
-                let parts: Vec<String> = obj
-                    .iter()
-                    .map(|(k, v)| format!("{}={}", k, v))
-                    .collect();
+                let parts: Vec<String> = obj.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
                 println!("{}", parts.join("\t"));
             }
         }
     }
     Ok(())
+}
+
+fn write_text_columns(value: &Value) -> Result<(), AppError> {
+    println!("index\tname\tsafe_name\tis_duplicate\tinferred_type\tnon_null_ratio\tformula_ratio");
+
+    if let Some(columns) = value["data"]["columns"].as_array() {
+        for column in columns {
+            let index = column["index"].as_u64().unwrap_or(0);
+            let name = column["name"].as_str().unwrap_or("");
+            let safe_name = column["safe_name"].as_str().unwrap_or("");
+            let is_duplicate = column["is_duplicate"].as_bool().unwrap_or(false);
+            let inferred_type = column["inferred_type"].as_str().unwrap_or("");
+            let non_null_ratio = format_ratio(column["non_null_ratio"].as_f64().unwrap_or(0.0));
+            let formula_ratio = format_ratio(column["formula_ratio"].as_f64().unwrap_or(0.0));
+
+            println!(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                index, name, safe_name, is_duplicate, inferred_type, non_null_ratio, formula_ratio
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn format_ratio(value: f64) -> String {
+    let rounded = (value * 1000.0).round() / 1000.0;
+    if (rounded.fract()).abs() < f64::EPSILON {
+        format!("{rounded:.0}")
+    } else {
+        let formatted = format!("{rounded:.3}");
+        formatted
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
+    }
 }
 
 fn write_text_cell(value: &Value) -> Result<(), AppError> {
@@ -161,10 +195,7 @@ fn write_text_rows(value: &Value) -> Result<(), AppError> {
     } else if let Some(records) = data["records"].as_array() {
         for record in records {
             if let Some(obj) = record.as_object() {
-                let parts: Vec<String> = obj
-                    .iter()
-                    .map(|(k, v)| format!("{}={}", k, v))
-                    .collect();
+                let parts: Vec<String> = obj.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
                 println!("{}", parts.join("\t"));
             }
         }

--- a/src/excel/workbook.rs
+++ b/src/excel/workbook.rs
@@ -244,6 +244,7 @@ fn create_sheet_from_range(
     }
 
     if let Some(formulas) = formula_range {
+        let (start_row, start_col) = formulas.start().unwrap_or((0, 0));
         for (row_idx, col_idx, formula) in formulas.used_cells() {
             if formula.is_empty() {
                 continue;
@@ -255,9 +256,13 @@ fn create_sheet_from_range(
                 format!("={formula}")
             };
 
-            let cell = &mut data[row_idx + 1][col_idx + 1];
-            cell.is_formula = true;
-            cell.formula = Some(normalized);
+            let row = start_row as usize + row_idx + 1;
+            let col = start_col as usize + col_idx + 1;
+            if row < data.len() && col < data[row].len() {
+                let cell = &mut data[row][col];
+                cell.is_formula = true;
+                cell.formula = Some(normalized);
+            }
         }
     }
 

--- a/tests/headless_inspect_test.rs
+++ b/tests/headless_inspect_test.rs
@@ -124,6 +124,70 @@ fn create_columns_contract_workbook(path: &std::path::Path) {
     workbook.save(path).unwrap();
 }
 
+fn create_table_detection_workbook(path: &std::path::Path) {
+    use rust_xlsxwriter::Workbook as XlsxWorkbook;
+
+    let mut workbook = XlsxWorkbook::new();
+
+    let single = workbook.add_worksheet();
+    single.set_name("SingleTable").unwrap();
+    single.write_string(0, 0, "order_id").unwrap();
+    single.write_string(0, 1, "customer").unwrap();
+    single.write_string(0, 2, "amount").unwrap();
+    single.write_string(1, 0, "1001").unwrap();
+    single.write_string(1, 1, "Alice").unwrap();
+    single.write_number(1, 2, 125.0).unwrap();
+    single.write_string(2, 0, "1002").unwrap();
+    single.write_string(2, 1, "Bob").unwrap();
+    single.write_number(2, 2, 250.0).unwrap();
+    single.write_string(3, 0, "1003").unwrap();
+    single.write_string(3, 1, "Carol").unwrap();
+    single.write_number(3, 2, 375.0).unwrap();
+
+    let multiple = workbook.add_worksheet();
+    multiple.set_name("MultipleTables").unwrap();
+    multiple.write_string(0, 0, "region").unwrap();
+    multiple.write_string(0, 1, "sales").unwrap();
+    multiple.write_string(1, 0, "East").unwrap();
+    multiple.write_number(1, 1, 10.0).unwrap();
+    multiple.write_string(2, 0, "West").unwrap();
+    multiple.write_number(2, 1, 12.0).unwrap();
+    multiple.write_string(0, 4, "sku").unwrap();
+    multiple.write_string(0, 5, "qty").unwrap();
+    multiple.write_string(0, 6, "status").unwrap();
+    multiple.write_string(1, 4, "A-1").unwrap();
+    multiple.write_number(1, 5, 5.0).unwrap();
+    multiple.write_string(1, 6, "open").unwrap();
+    multiple.write_string(2, 4, "B-2").unwrap();
+    multiple.write_number(2, 5, 7.0).unwrap();
+    multiple.write_string(2, 6, "closed").unwrap();
+    multiple.write_string(3, 4, "C-3").unwrap();
+    multiple.write_number(3, 5, 9.0).unwrap();
+    multiple.write_string(3, 6, "open").unwrap();
+
+    let preamble = workbook.add_worksheet();
+    preamble.set_name("Preamble").unwrap();
+    preamble.write_string(0, 0, "Quarterly export").unwrap();
+    preamble
+        .write_string(1, 0, "Generated for finance")
+        .unwrap();
+    preamble.write_string(3, 0, "Prepared by ops").unwrap();
+    preamble.write_string(4, 0, "invoice_id").unwrap();
+    preamble.write_string(4, 1, "customer").unwrap();
+    preamble.write_string(4, 2, "total").unwrap();
+    preamble.write_string(5, 0, "I-001").unwrap();
+    preamble.write_string(5, 1, "Delta").unwrap();
+    preamble.write_number(5, 2, 99.0).unwrap();
+    preamble.write_string(6, 0, "I-002").unwrap();
+    preamble.write_string(6, 1, "Echo").unwrap();
+    preamble.write_number(6, 2, 149.0).unwrap();
+
+    let empty = workbook.add_worksheet();
+    empty.set_name("EmptyTables").unwrap();
+
+    workbook.save(path).unwrap();
+}
+
 fn assert_json_success(output: &std::process::Output) -> serde_json::Value {
     assert!(
         output.status.success(),
@@ -846,6 +910,149 @@ fn test_inspect_columns_invalid_header_row() {
         .output()
         .expect("Failed to execute excel-cli");
     assert_json_error(&out_of_range, 6);
+}
+
+#[test]
+fn test_inspect_tables_single_table() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_tables_single.xlsx");
+    create_table_detection_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("tables")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("SingleTable")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    let json = assert_json_success(&output);
+    assert_eq!(json["command"], "inspect.tables");
+    assert_eq!(json["target"]["sheet"], "SingleTable");
+    assert_eq!(json["data"]["candidates"].as_array().unwrap().len(), 1);
+    assert_eq!(json["meta"]["candidate_count"], 1);
+
+    let candidate = &json["data"]["candidates"][0];
+    assert_eq!(candidate["range"], "A1:C4");
+    assert_eq!(candidate["header_row"], 1);
+    assert_eq!(candidate["column_count"], 3);
+    assert_eq!(candidate["row_count"], 4);
+    let confidence = candidate["confidence"].as_f64().unwrap();
+    assert!((0.7..=1.0).contains(&confidence));
+}
+
+#[test]
+fn test_inspect_tables_multiple_tables() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_tables_multiple.xlsx");
+    create_table_detection_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("tables")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("MultipleTables")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    let json = assert_json_success(&output);
+    let candidates = json["data"]["candidates"].as_array().unwrap();
+    assert_eq!(candidates.len(), 2);
+    assert!(json["data"].get("selected").is_none());
+    assert!(json["data"].get("recommended").is_none());
+
+    assert_eq!(candidates[0]["range"], "A1:B3");
+    assert_eq!(candidates[0]["header_row"], 1);
+    assert_eq!(candidates[0]["column_count"], 2);
+    assert_eq!(candidates[0]["row_count"], 3);
+    assert!((0.7..=1.0).contains(&candidates[0]["confidence"].as_f64().unwrap()));
+
+    assert_eq!(candidates[1]["range"], "E1:G4");
+    assert_eq!(candidates[1]["header_row"], 1);
+    assert_eq!(candidates[1]["column_count"], 3);
+    assert_eq!(candidates[1]["row_count"], 4);
+    assert!((0.7..=1.0).contains(&candidates[1]["confidence"].as_f64().unwrap()));
+}
+
+#[test]
+fn test_inspect_tables_preamble_late_header() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_tables_preamble.xlsx");
+    create_table_detection_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("tables")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("Preamble")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    let json = assert_json_success(&output);
+    let candidates = json["data"]["candidates"].as_array().unwrap();
+    assert_eq!(candidates.len(), 1);
+
+    let candidate = &candidates[0];
+    assert_eq!(candidate["range"], "A5:C7");
+    assert_eq!(candidate["header_row"], 5);
+    assert_eq!(candidate["column_count"], 3);
+    assert_eq!(candidate["row_count"], 3);
+    assert!((0.7..=1.0).contains(&candidate["confidence"].as_f64().unwrap()));
+}
+
+#[test]
+fn test_inspect_tables_empty_sheet() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_tables_empty.xlsx");
+    create_table_detection_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("tables")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("EmptyTables")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    let json = assert_json_success(&output);
+    assert_eq!(json["command"], "inspect.tables");
+    assert_eq!(json["target"]["sheet"], "EmptyTables");
+    assert_eq!(json["meta"]["candidate_count"], 0);
+    assert!(json["data"]["candidates"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn test_inspect_tables_text() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_tables_text.xlsx");
+    create_table_detection_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("tables")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("SingleTable")
+        .arg("--format")
+        .arg("text")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    assert!(output.status.success());
+    assert!(
+        output.stderr.is_empty(),
+        "Expected empty stderr on success. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("A1:C4\theader_row=1"));
+    assert!(stdout.contains("columns=3"));
+    assert!(stdout.contains("rows=4"));
+    assert!(stdout.contains("confidence="));
 }
 
 #[test]

--- a/tests/headless_inspect_test.rs
+++ b/tests/headless_inspect_test.rs
@@ -83,6 +83,47 @@ fn create_read_contract_workbook(path: &std::path::Path) {
     workbook.save(path).unwrap();
 }
 
+fn create_columns_contract_workbook(path: &std::path::Path) {
+    use rust_xlsxwriter::Workbook as XlsxWorkbook;
+
+    let mut workbook = XlsxWorkbook::new();
+
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("ColumnCases").unwrap();
+    sheet.write_string(0, 0, "customer").unwrap();
+    sheet.write_string(0, 1, "customer").unwrap();
+    sheet.write_string(0, 2, "").unwrap();
+    sheet.write_string(0, 3, "数量").unwrap();
+    sheet.write_string(0, 4, "mixed").unwrap();
+    sheet.write_string(0, 5, "active").unwrap();
+    sheet.write_string(0, 6, "total_formula").unwrap();
+    sheet.write_string(1, 0, "Alice").unwrap();
+    sheet.write_string(1, 1, "VIP").unwrap();
+    sheet.write_string(1, 2, "needs safe name").unwrap();
+    sheet.write_number(1, 3, 3.0).unwrap();
+    sheet.write_number(1, 4, 10.0).unwrap();
+    sheet.write_boolean(1, 5, true).unwrap();
+    sheet.write_formula(1, 6, "=D2*2").unwrap();
+    sheet.set_formula_result(1, 6, "6");
+    sheet.write_string(2, 0, "Bob").unwrap();
+    sheet.write_string(2, 1, "Standard").unwrap();
+    sheet.write_number(2, 3, 4.0).unwrap();
+    sheet.write_string(2, 4, "later").unwrap();
+    sheet.write_boolean(2, 5, false).unwrap();
+    sheet.write_formula(2, 6, "=D3*2").unwrap();
+    sheet.set_formula_result(2, 6, "8");
+
+    let offset = workbook.add_worksheet();
+    offset.set_name("OffsetHeader").unwrap();
+    offset.write_string(0, 0, "Quarterly export").unwrap();
+    offset.write_string(1, 0, "item").unwrap();
+    offset.write_string(1, 1, "amount").unwrap();
+    offset.write_string(2, 0, "Widget").unwrap();
+    offset.write_number(2, 1, 12.0).unwrap();
+
+    workbook.save(path).unwrap();
+}
+
 fn assert_json_success(output: &std::process::Output) -> serde_json::Value {
     assert!(
         output.status.success(),
@@ -680,6 +721,131 @@ fn test_inspect_sample_json() {
     assert_eq!(json["target"]["sheet"], "Orders");
     assert!(json["data"]["sample_mode"].is_string());
     assert!(json["data"]["rows"].is_array() || json["data"]["records"].is_array());
+}
+
+#[test]
+fn test_inspect_columns_json_contract() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_columns_contract.xlsx");
+    create_columns_contract_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("columns")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("ColumnCases")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    let json = assert_json_success(&output);
+    assert_eq!(json["schema_version"], "1.0");
+    assert_eq!(json["command"], "inspect.columns");
+    assert_eq!(json["file"]["format"], "xlsx");
+    assert_eq!(json["target"]["sheet"], "ColumnCases");
+    assert_eq!(json["target"]["sheet_index"], 0);
+    assert_eq!(json["meta"]["header_row_mode"], "auto");
+    assert_eq!(json["meta"]["resolved_header_row"], 1);
+    assert_eq!(json["meta"]["column_count"], 7);
+    assert_eq!(json["meta"]["data_row_count"], 2);
+    assert!(json["warnings"].as_array().unwrap().is_empty());
+
+    let columns = json["data"]["columns"].as_array().unwrap();
+    assert_eq!(columns.len(), 7);
+    assert_eq!(columns[0]["index"], 1);
+    assert_eq!(columns[0]["name"], "customer");
+    assert_eq!(columns[0]["safe_name"], "customer");
+    assert_eq!(columns[0]["is_duplicate"], true);
+    assert_eq!(columns[0]["inferred_type"], "string");
+    assert_eq!(columns[0]["non_null_ratio"], 1.0);
+    assert_eq!(columns[0]["formula_ratio"], 0.0);
+    assert_eq!(
+        columns[0]["sample_values"],
+        serde_json::json!(["Alice", "Bob"])
+    );
+
+    assert_eq!(columns[1]["name"], "customer");
+    assert_eq!(columns[1]["safe_name"], "customer_2");
+    assert_eq!(columns[1]["is_duplicate"], true);
+
+    assert_eq!(columns[2]["name"], "");
+    assert_eq!(columns[2]["safe_name"], "col_C");
+    assert_eq!(columns[2]["is_duplicate"], false);
+    assert_eq!(columns[2]["non_null_ratio"], 0.5);
+
+    assert_eq!(columns[3]["name"], "数量");
+    assert_eq!(columns[3]["safe_name"], "数量");
+    assert_eq!(columns[3]["inferred_type"], "number");
+    assert_eq!(columns[3]["sample_values"], serde_json::json!([3, 4]));
+
+    assert_eq!(columns[4]["inferred_type"], "mixed");
+    assert_eq!(columns[5]["inferred_type"], "boolean");
+    assert_eq!(columns[6]["inferred_type"], "number");
+    assert_eq!(columns[6]["formula_ratio"], 1.0);
+    assert_eq!(columns[6]["sample_values"], serde_json::json!([6, 8]));
+}
+
+#[test]
+fn test_inspect_columns_explicit_header_row_and_text() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_columns_text.xlsx");
+    create_columns_contract_workbook(&file_path);
+
+    let output = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("columns")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("OffsetHeader")
+        .arg("--header-row")
+        .arg("2")
+        .arg("--format")
+        .arg("text")
+        .output()
+        .expect("Failed to execute excel-cli");
+
+    assert!(
+        output.status.success(),
+        "Expected success. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.trim_start().starts_with('{'));
+    assert!(stdout.contains("index\tname\tsafe_name"));
+    assert!(stdout.contains("1\titem\titem\tfalse\tstring\t1\t0"));
+    assert!(stdout.contains("2\tamount\tamount\tfalse\tnumber\t1\t0"));
+}
+
+#[test]
+fn test_inspect_columns_invalid_header_row() {
+    let temp_dir = std::env::temp_dir();
+    let file_path = temp_dir.join("excel_cli_test_inspect_columns_bad_header.xlsx");
+    create_columns_contract_workbook(&file_path);
+
+    let non_numeric = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("columns")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("ColumnCases")
+        .arg("--header-row")
+        .arg("nope")
+        .output()
+        .expect("Failed to execute excel-cli");
+    assert_json_error(&non_numeric, 6);
+
+    let out_of_range = Command::new(excel_cli_bin())
+        .arg("inspect")
+        .arg("columns")
+        .arg(&file_path)
+        .arg("--sheet")
+        .arg("ColumnCases")
+        .arg("--header-row")
+        .arg("999")
+        .output()
+        .expect("Failed to execute excel-cli");
+    assert_json_error(&out_of_range, 6);
 }
 
 #[test]

--- a/tests/malformed_xlsx_test.rs
+++ b/tests/malformed_xlsx_test.rs
@@ -31,7 +31,11 @@ fn malformed_xlsx_inspect_workbook_returns_controlled_error() {
         "Expected failure for malformed workbook, got success"
     );
     let actual = output.status.code().unwrap_or(-1);
-    assert_eq!(actual, 4, "Expected exit code 4 (parse_error), got {}", actual);
+    assert_eq!(
+        actual, 4,
+        "Expected exit code 4 (parse_error), got {}",
+        actual
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -65,7 +69,11 @@ fn malformed_xlsx_read_cell_returns_controlled_error() {
         "Expected failure for malformed workbook in read mode, got success"
     );
     let actual = output.status.code().unwrap_or(-1);
-    assert_eq!(actual, 4, "Expected exit code 4 (parse_error), got {}", actual);
+    assert_eq!(
+        actual, 4,
+        "Expected exit code 4 (parse_error), got {}",
+        actual
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(


### PR DESCRIPTION
### Added
- `inspect columns` command to profile column headers, safe names, duplicate detection, inferred types, non-null/formula ratios, and sample values
- `inspect tables` command to detect table-like regions with ranges, header rows, dimensions, and confidence scores
- Regression coverage for structure inspection cases
- Release branch CI triggers for `release/**` branches

### Changed
- Updated description to reflect dual-mode capability (headless JSON API + interactive Vim-like TUI)
- Updated keywords for better crates.io discoverability